### PR TITLE
OPAL-682 reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.11-slim
+FROM python:3.11
 WORKDIR /home
 COPY . ./
-RUN pip install . 
+RUN pip install .
 RUN useradd -ms /bin/bash default
 USER default
 ENTRYPOINT ["/bin/bash", "/home/start_services.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.11
+FROM python:3.11-slim
 WORKDIR /home
 COPY . ./
-RUN pip install .
+RUN pip install . 
 RUN useradd -ms /bin/bash default
 USER default
 ENTRYPOINT ["/bin/bash", "/home/start_services.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11-slim
 WORKDIR /home
 COPY . ./
 RUN pip install .

--- a/task_queue/__init__.py
+++ b/task_queue/__init__.py
@@ -9,4 +9,4 @@ __all__ = [
     "config",
 ]
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"

--- a/task_queue/__init__.py
+++ b/task_queue/__init__.py
@@ -1,3 +1,3 @@
 """Task Queue.
 """
-__version__ = "1.4.8"
+__version__ = "1.4.9"


### PR DESCRIPTION
Other things I tried that didn't reduce the size (or reduced it by a negligible amount):
Ignoring test files
Combining run steps 

To build an image, in whatever directory your Dockerfile is, run: 
docker build . -t <name:tag>