### PR TITLE
Opal 1026 - Task Queue images do not build

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -18,7 +18,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: build image
         run: |
-          version=$(python setup.py --version)
+          version=$(python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "Task Queue Version = ${version}"
           docker build . -t ghcr.io/afmc-majcom/task-queue/task-queue:latest
           docker run ghcr.io/afmc-majcom/task-queue/task-queue:latest controller --help

--- a/.github/workflows/runners.yml
+++ b/.github/workflows/runners.yml
@@ -4,7 +4,7 @@ name: Task Queue CI/CD
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "OPAL-1026" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/runners.yml
+++ b/.github/workflows/runners.yml
@@ -4,7 +4,7 @@ name: Task Queue CI/CD
 
 on:
   push:
-    branches: [ "main", "OPAL-1026" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 ## Repository Organization
 
 ### Root
-<p>The root folder contains all of the necessary information about task-queue, including a <a href="https://github.com/AFMC-MAJCOM/task-queue/blob/main/README.md">README</a> and a <a href="https://github.com/AFMC-MAJCOM/task-queue/blob/main/setup.py">setup.py</a> file to setup the current version of task-queue</p>
+<p>The root folder contains all of the necessary information about task-queue, including a <a href="https://github.com/AFMC-MAJCOM/task-queue/blob/main/README.md">README</a> and a <a href="https://github.com/AFMC-MAJCOM/task-queue/blob/main/pyproject.toml">pyproject.toml</a> file to setup the current version of task-queue</p>
 
 ### .github/workflows
 <p>The <a href="https://github.com/AFMC-MAJCOM/task-queue/tree/main/.github/workflows">.github/workflows</a> folder contains the workflow for task-queue and will run tests.</p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "task_queue"
-version = "1.8.0"
+version = "1.8.1"
 
 dependencies = [
     "pendulum>=2.1.2",


### PR DESCRIPTION
Task queue images won't build because the runner is expecting setup.py but that file no longer exists. 

Fix the runners to read the version from the pyproject.toml file

Also updated the CONTRIBUTING.md to not mention setup.py