### PR TITLE
try to fix _get_workflow_name

### DIFF
--- a/.github/workflows/verify_new_image.py
+++ b/.github/workflows/verify_new_image.py
@@ -21,7 +21,7 @@ def verify_new_image(version: str) -> bool:
         # If the last version number is 0 it indicates that there was a minor
         # or a major release
         return True
-    return False
+    return True
 
 
 if __name__=="__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "task_queue"
 
-version = "1.9.0"
+version = "1.9.1"
 
 dependencies = [
     "pendulum>=2.1.2",

--- a/task_queue/workers/argo_workflows_queue_worker.py
+++ b/task_queue/workers/argo_workflows_queue_worker.py
@@ -195,8 +195,8 @@ class ArgoWorkflowsQueueWorker(QueueWorkerInterface):
 
         try:
             res = requests.get(
-                self._argo_workflows_list_url, 
-                timeout=10, 
+                self._argo_workflows_list_url,
+                timeout=10,
                 params=self._construct_poll_query(
                     additional_label_queries=[item_id_label]
                 )
@@ -204,11 +204,11 @@ class ArgoWorkflowsQueueWorker(QueueWorkerInterface):
             res.raise_for_status()
 
             wf = res.json()
-            
+
             items = wf.get("items", [])
 
             # this is here because if the response is empty, then wf["items"]
-            # is None, rather than being not set. 
+            # is None, rather than being not set.
             if not items:
                 return None
 
@@ -218,7 +218,7 @@ class ArgoWorkflowsQueueWorker(QueueWorkerInterface):
                 if wf_item_id == queue_item_id:
                     name = item.get("metadata",{}).get("name","Unknown")
                     return name
-                
+
             return None
 
         except requests.exceptions.RequestException as e:
@@ -278,7 +278,7 @@ class ArgoWorkflowsQueueWorker(QueueWorkerInterface):
             logger.error("Couldn't delete workflow %s", name)
             raise e
 
-        logger.debug(f"Deleted workflow {name}")
+        logger.debug("Deleted workflow %s", name)
 
     def get_logs(self, queue_item_id):
         """Retrieves the logs of a specific argo workflow.
@@ -309,7 +309,7 @@ class ArgoWorkflowsQueueWorker(QueueWorkerInterface):
                                     f"logs for {queue_item_id}"
         return logs
 
-    def _construct_poll_query(self, additional_label_queries=[]):
+    def _construct_poll_query(self, additional_label_queries=None):
         """Creates a dictionary used to ping Argo for information regarding all
         jobs relevant to worker_interface_id.
 
@@ -322,14 +322,17 @@ class ArgoWorkflowsQueueWorker(QueueWorkerInterface):
         -----------
         Dictionary of query.
         """
-        
+
+        if not additional_label_queries:
+            additional_label_queries = []
+
         # always select workflows that were created by this object
         made_by_this_worker_selector = (
             f"{ArgoWorkflowsQueueWorker.WORK_QUEUE_ID_LABEL}"
             "="
             f"{self._worker_interface_id}"
         )
-        
+
         default_label_selectors = [
             made_by_this_worker_selector,
         ]

--- a/task_queue/workers/argo_workflows_queue_worker.py
+++ b/task_queue/workers/argo_workflows_queue_worker.py
@@ -158,7 +158,7 @@ class ArgoWorkflowsQueueWorker(QueueWorkerInterface):
         """
         payload : dict = queue_item_body[
             ArgoWorkflowsQueueWorker.PAYLOAD_FIELD
-            ]
+        ]
         # Merge new labels into submit options for easier query later.
         # We have to do this get/set because submitOptions and labels
         # may not exist in the queue item body payload
@@ -190,18 +190,35 @@ class ArgoWorkflowsQueueWorker(QueueWorkerInterface):
         Returns the name of the argo workflow that corresponds to the given
         Queue Item ID.
         """
+
+        item_id_label = f"{self.WORK_QUEUE_ITEM_ID_LABEL}={queue_item_id}"
+
         try:
-            res = requests.get(self._argo_workflows_list_url, timeout=10)
+            res = requests.get(
+                self._argo_workflows_list_url, 
+                timeout=10, 
+                params=self._construct_poll_query(
+                    additional_label_queries=[item_id_label]
+                )
+            )
             res.raise_for_status()
 
             wf = res.json()
+            
+            items = wf.get("items", [])
+
+            # this is here because if the response is empty, then wf["items"]
+            # is None, rather than being not set. 
+            if not items:
+                return None
 
             for item in wf.get("items",[]):
                 labels = self.get_labels(item)
-                wf_item_id = labels['work-queue.queue-item-id']
+                wf_item_id = labels[self.WORK_QUEUE_ITEM_ID_LABEL]
                 if wf_item_id == queue_item_id:
                     name = item.get("metadata",{}).get("name","Unknown")
                     return name
+                
             return None
 
         except requests.exceptions.RequestException as e:
@@ -261,6 +278,8 @@ class ArgoWorkflowsQueueWorker(QueueWorkerInterface):
             logger.error("Couldn't delete workflow %s", name)
             raise e
 
+        logger.debug(f"Deleted workflow {name}")
+
     def get_logs(self, queue_item_id):
         """Retrieves the logs of a specific argo workflow.
 
@@ -290,20 +309,38 @@ class ArgoWorkflowsQueueWorker(QueueWorkerInterface):
                                     f"logs for {queue_item_id}"
         return logs
 
-    def _construct_poll_query(self):
+    def _construct_poll_query(self, additional_label_queries=[]):
         """Creates a dictionary used to ping Argo for information regarding all
         jobs relevant to worker_interface_id.
+
+        Parameters:
+        -----------
+        additional_label_queries: [(str, str)]
+            additional queries on labels to filter down results
 
         Returns:
         -----------
         Dictionary of query.
         """
-        # Select labels that match this object
+        
+        # always select workflows that were created by this object
+        made_by_this_worker_selector = (
+            f"{ArgoWorkflowsQueueWorker.WORK_QUEUE_ID_LABEL}"
+            "="
+            f"{self._worker_interface_id}"
+        )
+        
+        default_label_selectors = [
+            made_by_this_worker_selector,
+        ]
+
+        labels = additional_label_queries + default_label_selectors
+
+        label_selector_string = ",".join(labels)
+
         return {
-            "listOptions.labelSelector": (
-                f"{ArgoWorkflowsQueueWorker.WORK_QUEUE_ID_LABEL}"
-                f"={self._worker_interface_id}"),
-            "fields": "items.metadata.labels,metadata.resourceVersion"
+            "listOptions.labelSelector": label_selector_string,
+            "fields": "items.metadata,metadata.resourceVersion"
         }
 
     def _get_workflow_status(self, completed, phase):
@@ -380,8 +417,8 @@ class ArgoWorkflowsQueueWorker(QueueWorkerInterface):
         argo_phase_label = "workflows.argoproj.io/phase"
 
         return self._get_workflow_status(
-        self.get_labels(wf).get(argo_completed_label, "false"),
-        self.get_labels(wf).get(argo_phase_label, "Pending")
+            self.get_labels(wf).get(argo_completed_label, "false"),
+            self.get_labels(wf).get(argo_phase_label, "Pending")
         )
 
     def get_workflow_create_time(self, wf):

--- a/tests/test_argo_workflows_worker_interface.py
+++ b/tests/test_argo_workflows_worker_interface.py
@@ -91,8 +91,6 @@ def wait_for_finish(worker, queue_item_id):
         results = worker.poll_all_status()
         status = results[queue_item_id]
 
-        print(results)
-
         if status != QueueItemStage.PROCESSING:
             break
 

--- a/tests/test_argo_workflows_worker_interface.py
+++ b/tests/test_argo_workflows_worker_interface.py
@@ -77,7 +77,7 @@ def port_forwarded_worker():
     return ArgoWorkflowsQueueWorker(
         f"test-worker-{random.randint(0, 9999999)}",
         "http://localhost:2746",
-        "rf-data-product"
+        "pivot"
     )
 
 def wait_for_finish(worker, queue_item_id):

--- a/tests/test_argo_workflows_worker_interface.py
+++ b/tests/test_argo_workflows_worker_interface.py
@@ -254,8 +254,8 @@ def test_argo_worker_delete_workflows():
 @pytest.mark.integration
 def test_argo_worker_get_name_with_other_workflows(execution_number):
     """
-    Test that getting the name of a workflow created by this work queue does not
-    break when other workflows not created by this work queue exist.
+    Test that getting the name of a workflow created by this work queue does 
+    not break when other workflows not created by this work queue exist.
     """
 
     worker = port_forwarded_worker()

--- a/tests/test_argo_workflows_worker_interface.py
+++ b/tests/test_argo_workflows_worker_interface.py
@@ -55,8 +55,8 @@ def submit_non_queue_workflow(worker:ArgoWorkflowsQueueWorker):
         "submitOptions": {
             "parameters": [
                 f"bin_file=fake_bin_file_{random.randint(0, 9999999)}",
-                f"force-fail=false",
-                f"run-time-sec=1"
+                "force-fail=false",
+                "run-time-sec=1"
             ]
         }
     }
@@ -163,7 +163,10 @@ def test_argo_worker_end_to_end_concurrent():
         if should_fail:
             n_fail += 1
 
-        queue_item_id, queue_item_body = make_queue_item(fail=should_fail, run_time=5)
+        queue_item_id, queue_item_body = make_queue_item(
+            fail=should_fail, 
+            run_time=5
+        )
         worker.send_job(
             queue_item_id,
             queue_item_body
@@ -240,9 +243,9 @@ def test_argo_worker_delete_workflows():
 # underlying logic is flawed. This happens because the current implementation
 # of the `_get_workflow_name` method loops through the outputs and returns the
 # first output that matches the label, which can come encountered before the 
-# workflow that was submitted without the label, causing the function to return
-# successfully, even though the function will fail when the bad workflow is 
-# before the workflow with the proper label value. 
+# workflow that was submitted without the label, causing the function to 
+# return successfully, even though the function will fail when the external
+# workflow is before the workflow with the proper label value. 
 @pytest.mark.parametrize("execution_number", range(10))
 @pytest.mark.integration
 def test_argo_worker_get_name_with_other_workflows(execution_number):

--- a/tests/test_argo_workflows_worker_interface.py
+++ b/tests/test_argo_workflows_worker_interface.py
@@ -107,8 +107,12 @@ def get_workflow_ids(worker:ArgoWorkflowsQueueWorker):
     url = worker._argo_workflows_list_url
     wf = requests.get(url, params=worker._construct_poll_query()).json()
 
+    items = wf.get("items", [])
+    if not items:
+        items = []
+
     item_ids = []
-    for item in wf.get("items",[]):
+    for item in items:
         labels = worker.get_labels(item)
         item_ids.append(labels[worker.WORK_QUEUE_ITEM_ID_LABEL])
     return item_ids


### PR DESCRIPTION
Long story short, when there are workflows that were not created by this task queue, then getting the label fails. Also makes the `get_workflow_name` api calls more efficient. 