### PR TITLE
The `SQLQueue` constructor is broken.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "task_queue"
 
-version = "1.12.0"
+version = "1.13.0"
 
 dependencies = [
     "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
 [project.optional-dependencies]
 s3 = [
     "s3fs>=2023.6.0",
+    # botocore >= 1.36.0 changes how hashes work, which breaks minio
+    # compatibility. It is still compatible with AWS S3 so far.
+    "botocore<1.36.0"
 ]
 
 sql = [

--- a/task_queue/queues/sql_queue.py
+++ b/task_queue/queues/sql_queue.py
@@ -1,11 +1,10 @@
 """Wherein is contained the functions for implementing the SQL Queue.
 """
-from typing import Optional
+from typing import Optional, Any
 import json
 
 from sqlmodel import Field, Session, SQLModel, select, func, UniqueConstraint
 from sqlalchemy.dialects.postgresql import insert, JSONB
-from typing import Any
 from sqlalchemy import Engine, Column
 
 from task_queue import logger

--- a/task_queue/queues/sql_queue.py
+++ b/task_queue/queues/sql_queue.py
@@ -35,7 +35,7 @@ def new_sql_queue_table(tablename:str, constraint_name:str):
 
         id: Optional[int] = Field(default=None, primary_key=True)
         queue_item_stage: Optional[int] = QueueItemStage.WAITING.value
-        json_data: Any = Field(sa_column=Column(JSONB))
+        json_data: JSONB = Field(sa_column=Column(JSONB))
         index_key: str
         queue_name: str
     return SqlQueueTable

--- a/task_queue/queues/sql_queue.py
+++ b/task_queue/queues/sql_queue.py
@@ -35,7 +35,7 @@ def new_sql_queue_table(tablename:str, constraint_name:str):
 
         id: Optional[int] = Field(default=None, primary_key=True)
         queue_item_stage: Optional[int] = QueueItemStage.WAITING.value
-        json_data: JSONB = Field(sa_column=Column(JSONB))
+        json_data: dict[Any, Any] = Field(sa_column=Column(JSONB))
         index_key: str
         queue_name: str
     return SqlQueueTable

--- a/task_queue/queues/sql_queue.py
+++ b/task_queue/queues/sql_queue.py
@@ -4,7 +4,8 @@ from typing import Optional
 import json
 
 from sqlmodel import Field, Session, SQLModel, select, func, UniqueConstraint
-from sqlalchemy.dialects.postgresql import insert, JSONB, Any
+from sqlalchemy.dialects.postgresql import insert, JSONB
+from typing import Any
 from sqlalchemy import Engine, Column
 
 from task_queue import logger


### PR DESCRIPTION
Error message: 

```
main Using sql queue implementation
main Traceback (most recent call last):
main   File "/argo/staging/script", line 34, in <module>
main     base_queue = sqlq.json_sql_queue(engine, sql_queue_name)
main           
main   File "/usr/local/lib/python3.11/site-packages/task_queue/queues/sql_queue.py", line 365, in json_sql_queue
main     return SQLQueue(engine, queue_name)
main            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/task_queue/queues/sql_queue.py", line 53, in __init__
main     self.sql_queue = new_sql_queue_table(tablename, constraint_name)
main                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/task_queue/queues/sql_queue.py", line 25, in new_sql_queue_table
main     class SqlQueueTable(SQLModel, table=True):
main   File "/usr/local/lib/python3.11/site-packages/sqlmodel/main.py", line 536, in __new__
main     new_cls = super().__new__(cls, name, bases, dict_used, **config_kwargs)
main               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_model_construction.py", line 237, in __new__
main     complete_model_class(
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_model_construction.py", line 597, in complete_model_class
main     schema = gen_schema.generate_schema(cls)
main              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 706, in generate_schema
main     schema = self._generate_schema_inner(obj)
main              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 984, in _generate_schema_inner
main     return self._model_schema(obj)
main            ^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 817, in _model_schema
main     {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
main     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 817, in <dictcomp>
main     {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
main         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1186, in _generate_md_field_schema
main     common_field = self._common_field_schema(name, field_info, decorators)
main                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1352, in _common_field_schema
main     schema = self._apply_annotations(
main              ^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 2264, in _apply_annotations
main     schema = get_inner_schema(source_type)
main              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_schema_generation_shared.py", line 83, in __call__
main     schema = self._handler(source_type)
main              ^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 2246, in inner_handler
main     schema = self._generate_schema_inner(obj)
main              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 989, in _generate_schema_inner
main     return self.match_type(obj)
main            ^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1090, in match_type
main     return self._call_schema(obj)
main            ^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1974, in _call_schema
main     arguments_schema = self._arguments_schema(function)
main                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 2006, in _arguments_schema
main     type_hints = _typing_extra.get_function_type_hints(function, globalns=globalns, localns=localns)
main                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_typing_extra.py", line 551, in get_function_type_hints
main     type_hints[name] = eval_type_backport(value, globalns, localns, type_params)
main                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_typing_extra.py", line 429, in eval_type_backport
main     return _eval_type_backport(value, globalns, localns, type_params)
main            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_typing_extra.py", line 466, in _eval_type_backport
main     return _eval_type(value, globalns, localns, type_params)
main            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_typing_extra.py", line 500, in _eval_type
main     return typing._eval_type(  # type: ignore
main            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/lib64/python3.11/typing.py", line 395, in _eval_type
main     return t._evaluate(globalns, localns, recursive_guard)
main            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "/usr/lib64/python3.11/typing.py", line 905, in _evaluate
main     eval(self.__forward_code__, globalns, localns),
main     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
main   File "<string>", line 1, in <module>
main NameError: name 'typing_Any' is not defined
main time="2025-04-08T16:29:23.105Z" level=info msg="sub-process exited" argo=true error="<nil>"
main Error: exit status 1
```